### PR TITLE
Fix the Onboarding information hint label for iPhone 7 and 5s screens

### DIFF
--- a/Pods/Pods.xcodeproj/xcuserdata/wissaaymz.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Pods/Pods.xcodeproj/xcuserdata/wissaaymz.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Anchorage.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>DeviceKit.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+		<key>Hero.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
+		<key>MarkdownView-MarkdownView.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>6</integer>
+		</dict>
+		<key>MarkdownView.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>5</integer>
+		</dict>
+		<key>Pods-swift_algorithms.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>7</integer>
+		</dict>
+		<key>Pods-swift_algorithmsTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>8</integer>
+		</dict>
+		<key>Pods-swift_algorithmsUITests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>9</integer>
+		</dict>
+		<key>Result.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>10</integer>
+		</dict>
+		<key>lottie-ios.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/swift_algorithms.xcodeproj/xcuserdata/wissaaymz.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/swift_algorithms.xcodeproj/xcuserdata/wissaaymz.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>swift_algorithms.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/swift_algorithms/Controllers/OnboardingInformationViewController.swift
+++ b/swift_algorithms/Controllers/OnboardingInformationViewController.swift
@@ -40,18 +40,20 @@ final class OnboardingInformationViewController: UIViewController {
             return view
         }
         
+        let genericHeight = view.frame.height / 50
+        
         let onboardStack = UIStackView(arrangedSubviews: onboardItemViews)
         onboardStack.axis = .vertical
-        onboardStack.spacing = 24
+        onboardStack.spacing = genericHeight
         
         actionContainer.addSubview(action)
         action.heightAnchor == 50
         action.setTitle("Continue", for: .normal)
-        action.edgeAnchors == actionContainer.edgeAnchors + UIEdgeInsets(top: 36, left: 0, bottom: 0, right: 0)
+        action.edgeAnchors == actionContainer.edgeAnchors + UIEdgeInsets(top: genericHeight, left: 0, bottom: 0, right: 0)
         
         let stack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel, onboardStack, actionContainer])
         stack.axis = .vertical
-        stack.spacing = 36
+        stack.spacing = genericHeight
         
         view.addSubview(stack)
         stack.horizontalAnchors == view.horizontalAnchors + 48
@@ -72,13 +74,18 @@ final class OnboardingInformationViewController: UIViewController {
     private func makeOnboardingProperties() -> Properties {
         let attributedTitle = NSMutableAttributedString()
         
+        var fontSize = CGFloat(42)
+        if view.frame.height < 600 {
+            fontSize = 30
+        }
+        
         let prefixAttributes = [
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 42, weight: .black),
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: fontSize, weight: .black),
             NSAttributedString.Key.foregroundColor : UIColor.black
         ]
         
         let titleAttributes = [
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 42, weight: .black),
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: fontSize, weight: .black),
             NSAttributedString.Key.foregroundColor : UIColor.coral()
         ]
         


### PR DESCRIPTION
Changed the height values to be in respect to the screen height. So that the shake to change to dark mode label would appear on iPhone 7 and 5s